### PR TITLE
Add event object and scope to onEnter/onLeave calls

### DIFF
--- a/src/waypoint.jsx
+++ b/src/waypoint.jsx
@@ -83,7 +83,12 @@ const Waypoint = React.createClass({
     return window;
   },
 
-  _handleScroll: function() {
+  /**
+   * @param {Object} event the native scroll event coming from the scrollable
+   *   parent, or resize event coming from the window. Will be undefined if
+   *   called by a React lifecyle method
+   */
+  _handleScroll: function(event) {
     const isVisible = this._isVisible();
 
     if (this._wasVisible === isVisible) {
@@ -92,9 +97,9 @@ const Waypoint = React.createClass({
     }
 
     if (isVisible) {
-      this.props.onEnter();
+      this.props.onEnter.call(this, event);
     } else {
-      this.props.onLeave();
+      this.props.onLeave.call(this, event);
     }
 
     this._wasVisible = isVisible;


### PR DESCRIPTION
React event handlers are not bound to the parent scope with ES6.
This means that `this.props.onEnter` will be called with the scope
of `props` rather than the component or its parent. Also, it's
valuable to be able to determine the cause of a Waypoint event.
